### PR TITLE
[efficientnet/model.py] Fix TensorFlow is_keras_tensor AttributeError

### DIFF
--- a/efficientnet/model.py
+++ b/efficientnet/model.py
@@ -366,7 +366,11 @@ def EfficientNet(width_coefficient,
     if input_tensor is None:
         img_input = layers.Input(shape=input_shape)
     else:
-        if not backend.is_keras_tensor(input_tensor):
+        if backend.backend() == 'tensorflow':
+            from tensorflow.python.keras.backend import is_keras_tensor
+        else:
+            is_keras_tensor = backend.is_keras_tensor
+        if not is_keras_tensor(input_tensor):
             img_input = layers.Input(tensor=input_tensor, shape=input_shape)
         else:
             img_input = input_tensor


### PR DESCRIPTION
Running TensorFlow 1.14.0 with your model, and got this error:
```
   File "/opt/venvs/tflow3.6.8/lib/python3.6/site-packages/ml_glaucoma/models/efficientnet.py", line 45, in efficient_net
     input_tensor=inputs, **kwargs).outputs
   File "/opt/venvs/tflow3.6.8/lib/python3.6/site-packages/efficientnet/__init__.py", line 57, in wrapper
     return func(*args, **kwargs)
   File "/opt/venvs/tflow3.6.8/lib/python3.6/site-packages/efficientnet/model.py", line 548, in EfficientNetB4
     **kwargs)
   File "/opt/venvs/tflow3.6.8/lib/python3.6/site-packages/efficientnet/model.py", line 369, in EfficientNet
     if not backend.is_keras_tensor(input_tensor):
   File "/opt/venvs/tflow3.6.8/lib/python3.6/site-packages/tensorflow/python/util/deprecation_wrapper.py", line 106, in __getattr__
     attr = getattr(self._dw_wrapped_module, name)
 AttributeError: module 'tensorflow.python.keras.api._v1.keras.backend' has no attribute 'is_keras_tensor'
```

Solved by using `is_keras_tensor` from elsewhere in `tensorflow` module.