### PR TITLE
Fixed get_custom_objects() import

### DIFF
--- a/efficientnet/__init__.py
+++ b/efficientnet/__init__.py
@@ -68,7 +68,7 @@ def init_keras_custom_objects():
         'FixedDropout': inject_keras_modules(model.get_dropout)()
     }
 
-    keras.utils.generic_utils.get_custom_objects().update(custom_objects)
+    keras.utils.get_custom_objects().update(custom_objects)
 
 
 def init_tfkeras_custom_objects():

--- a/efficientnet/__init__.py
+++ b/efficientnet/__init__.py
@@ -67,8 +67,11 @@ def init_keras_custom_objects():
         'swish': inject_keras_modules(model.get_swish)(),
         'FixedDropout': inject_keras_modules(model.get_dropout)()
     }
-
-    keras.utils.get_custom_objects().update(custom_objects)
+    
+    try:
+        keras.utils.generic_utils.get_custom_objects().update(custom_objects)
+    except AttributeError:
+        keras.utils.get_custom_objects().update(custom_objects)
 
 
 def init_tfkeras_custom_objects():


### PR DESCRIPTION
The issue of an old import has been fixed. `keras.utils.generic_utils` is now `keras.utils`.

References:

- [TF Documentation](https://www.tensorflow.org/api_docs/python/tf/keras/utils/get_custom_objects)
- [Keras Documentation](https://keras.io/api/utils/serialization_utils/#get_custom_objects-function)

Fixed #127 