### PR TITLE
Fixed calculation of "num_blocks_total".

### DIFF
--- a/efficientnet/model.py
+++ b/efficientnet/model.py
@@ -352,7 +352,8 @@ def EfficientNet(width_coefficient,
     x = layers.Activation(activation, name='stem_activation')(x)
 
     # Build blocks
-    num_blocks_total = sum(block_args.num_repeat for block_args in blocks_args)
+    num_blocks_total = sum(round_repeats(block_args.num_repeat,
+                                         depth_coefficient) for block_args in blocks_args)
     block_num = 0
     for idx, block_args in enumerate(blocks_args):
         assert block_args.num_repeat > 0


### PR DESCRIPTION
I fixed the calculation of "num_blocks_total" such that the linear decay for the drop connections will be calculated correctly.

The current implementation only calculates the linear decay correctly when phi=0 (i e. EfficientNetB0), which in turn results in unnecessary regularization of deeper configurations.

I believe my PR might be related to #60 & #135